### PR TITLE
los_hwi: Fix strict-prototypes compiler warning

### DIFF
--- a/platform/cpu/arm/cortex-m4/los_hwi.h
+++ b/platform/cpu/arm/cortex-m4/los_hwi.h
@@ -81,7 +81,7 @@ typedef VOID (* HWI_PROC_FUNC)(void);
  * @ingroup  los_hwi
  * Define the type of a hardware interrupt vector table function.
  */
-typedef VOID (**HWI_VECTOR_FUNC)();
+typedef VOID (**HWI_VECTOR_FUNC)(void);
 
 
 /**


### PR DESCRIPTION
Fix gcc compiler warning:

`error: function declaration isn't a prototype [-Werror=strict-prototypes]`