### PR TITLE
chore(stm32f429): add GNU ARM Embedded Toolchain version detection

### DIFF
--- a/doc/LiteOS_Compile_Guide_stm32f429_Gcc.md
+++ b/doc/LiteOS_Compile_Guide_stm32f429_Gcc.md
@@ -120,7 +120,7 @@
 	<td>安装arm-none-eabi-gcc的操作系统</td>
 	</tr>
 	<tr>
-	<td>arm-none-eabi-gcc(gcc version 6.2.1以上版本)</td>
+	<td>arm-none-eabi-gcc(gcc version 5.4以上版本)</td>
 	<td>用于编译、链接、调试程序代码</td>
 	</tr>
 	<tr>

--- a/kernel/link/gcc/cmsis_gcc.h
+++ b/kernel/link/gcc/cmsis_gcc.h
@@ -36,6 +36,12 @@
 #define __CMSIS_GCC_H
 
 
+#if defined ( __GNUC__)
+#if ( __GNUC__ < 5 ) || (__GNUC__ == 5 && __GNUC_MINOR__ < 4)
+#error "Please use arm-none-eabi-gcc version more higher than 5.4"
+#endif
+#endif
+
 #include <sys/_stdint.h>
 /* ignore some GCC warnings */
 #if defined ( __GNUC__ )


### PR DESCRIPTION
Guide to use the proper GNU ARM Embedded Toolchain version。