### PR TITLE
fix(mem):fix CI error in iar and gcc

### DIFF
--- a/kernel/base/mem/los_memory.c
+++ b/kernel/base/mem/los_memory.c
@@ -46,7 +46,17 @@ extern "C" {
 #endif /* __cplusplus */
 
 extern UINT8 *m_aucSysMem0;
-__align(4) UINT8 g_ucMemStart[OS_SYS_MEM_SIZE];
+	
+#ifdef LOS_PACK_ALIGN_4_IAR
+#pragma data_alignment=4
+#endif
+#ifdef LOS_PACK_ALIGN_4_KEIL
+__align(4)
+#endif
+#ifdef LOS_PACK_ALIGN_4_GCC
+__attribute__ ((aligned (4)))
+#endif 
+UINT8 g_ucMemStart[OS_SYS_MEM_SIZE];
 
 LITE_OS_SEC_TEXT_INIT UINT32 osMemSystemInit()
 {

--- a/kernel/link/gcc/los_builddef.h
+++ b/kernel/link/gcc/los_builddef.h
@@ -189,6 +189,10 @@ extern "C" {
 #define LITE_OS_SEC_BSS_MINOR
 #endif
 
+#ifndef LOS_PACK_ALIGN_4_GCC
+#define LOS_PACK_ALIGN_4_GCC
+#endif
+
 #ifndef LOS_PACK_ALIGN_8_GCC
 #define LOS_PACK_ALIGN_8_GCC
 #endif

--- a/kernel/link/iar/los_builddef.h
+++ b/kernel/link/iar/los_builddef.h
@@ -189,6 +189,10 @@ extern "C" {
 #define LITE_OS_SEC_BSS_MINOR
 #endif
 
+#ifndef LOS_PACK_ALIGN_4_IAR
+#define LOS_PACK_ALIGN_4_IAR
+#endif
+
 #ifndef LOS_PACK_ALIGN_8_IAR
 #define LOS_PACK_ALIGN_8_IAR
 #endif

--- a/kernel/link/keil/los_builddef.h
+++ b/kernel/link/keil/los_builddef.h
@@ -189,6 +189,10 @@ extern "C" {
 #define LITE_OS_SEC_BSS_MINOR
 #endif
 
+#ifndef LOS_PACK_ALIGN_4_KEIL
+#define LOS_PACK_ALIGN_4_KEIL
+#endif
+
 #ifndef LOS_PACK_ALIGN_8_KEIL
 #define LOS_PACK_ALIGN_8_KEIL
 #endif


### PR DESCRIPTION
Mem align keyword was defrent for IED tools.

Close #107