### PR TITLE
integrate stm32f103x official libs to PLAT[STM32F103-ISO]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,11 @@ INCLUDES += "-I${SOURCE_ROOT}/platform/${PLAT}/hal"
 INCLUDES += "-I${SOURCE_ROOT}/platform/${PLAT}/riscv_hal"
 endif
 
-
+ifeq (${PLAT},STM32F103ZE-ISO)
+CFLAGS +=-DLOS_STM32F103ZE -DSTM32F10X_HD -DUSE_STDPERIPH_DRIVER
+INCLUDES += "-I${SOURCE_ROOT}/platform/${PLAT}/Libraries/FWlib/inc"
+INCLUDES += "-I${SOURCE_ROOT}/platform/${PLAT}/Libraries/CMSIS"
+endif
 
 
 

--- a/kernel/cpu/arm/cortex-m3/los_dispatch_gcc.s
+++ b/kernel/cpu/arm/cortex-m3/los_dispatch_gcc.s
@@ -54,14 +54,14 @@ LOS_StartToRun:
     add     r12, r12, #36
 
     ldmfd   r12!, {r0-r7}
-    ; add     r12, r12, #72 
+    #; add     r12, r12, #72 
     msr     psp, r12
     push    {r0}
     mov     r0, #3
     msr     CONTROL, r0
     pop     {r0}
-    ; vpush    {s0} 
-    ; vpop     {s0} 
+    #; vpush    {s0} 
+    #; vpop     {s0} 
 
     mov     lr, r5
     msr     xpsr, r7
@@ -130,7 +130,7 @@ TaskSwitch:
     mrs     r0, psp
 
     stmfd   r0!, {r4-r12}
-    ; vstmdb  r0!, {d8-d15} 
+    #; vstmdb  r0!, {d8-d15} 
 
     ldr     r5, =g_stLosTask
     ldr     r6, [r5]
@@ -154,7 +154,7 @@ TaskSwitch:
     strh    r7,  [r0 , #4]
 
     ldr     r1,   [r0]
-    ; vldmia  r1!, {d8-d15} 
+    #; vldmia  r1!, {d8-d15} 
     ldmfd   r1!, {r4-r12}
     msr     psp,  r1
 

--- a/platform/STM32F103ZE-ISO/Libraries/CMSIS/stm32f10x.h
+++ b/platform/STM32F103ZE-ISO/Libraries/CMSIS/stm32f10x.h
@@ -15,15 +15,15 @@
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e. 
-  *                code will be based on direct access to peripheral’s registers 
+  *              - To use or not the peripheralï¿½s drivers in application code(i.e. 
+  *                code will be based on direct access to peripheralï¿½s registers 
   *                rather than drivers API), this option is controlled by 
   *                "#define USE_STDPERIPH_DRIVER"
   *              - To change few application-specific parameters such as the HSE 
   *                crystal frequency
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -42,7 +42,7 @@
 /** @addtogroup CMSIS
   * @{
   */
-
+  #include <stdint-gcc.h>
 /** @addtogroup stm32f10x
   * @{
   */
@@ -54,6 +54,7 @@
  extern "C" {
 #endif 
   
+
 /** @addtogroup Library_configuration_section
   * @{
   */

--- a/platform/STM32F103ZE-ISO/LiteOS.ld
+++ b/platform/STM32F103ZE-ISO/LiteOS.ld
@@ -15,7 +15,7 @@
 **
 **  Environment : Atollic TrueSTUDIO(R)
 **
-**  Distribution: The file is distributed “as is,” without any warranty
+**  Distribution: The file is distributed ï¿½as is,ï¿½ without any warranty
 **                of any kind.
 **
 **  (c)Copyright Atollic AB.
@@ -40,7 +40,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 128K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
 RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K
 }
 

--- a/platform/STM32F103ZE-ISO/LiteOS.ld
+++ b/platform/STM32F103ZE-ISO/LiteOS.ld
@@ -41,7 +41,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 128K
-RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 16K
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K
 }
 
 /* Define output sections */

--- a/platform/STM32F103ZE-ISO/Makefile
+++ b/platform/STM32F103ZE-ISO/Makefile
@@ -3,8 +3,11 @@ DIRECTORIES += platform/STM32F103ZE-ISO
 C_SOURCES += platform/STM32F103ZE-ISO/los_bsp_adapter.c  \
 			 platform/STM32F103ZE-ISO/los_bsp_key.c  \
 			 platform/STM32F103ZE-ISO/los_bsp_led.c  \
-			 platform/STM32F103ZE-ISO/los_bsp_uart.c
-			 
+			 platform/STM32F103ZE-ISO/los_bsp_uart.c \
+			 platform/STM32F103ZE-ISO/Libraries/FWlib/src/stm32f10x_gpio.c \
+			 platform/STM32F103ZE-ISO/Libraries/FWlib/src/stm32f10x_rcc.c \
+			 platform/STM32F103ZE-ISO/Libraries/FWlib/src/stm32f10x_usart.c
+
 
 ASM_SOURCES += platform/STM32F429I_DISCO/los_startup_gcc.s
              


### PR DESCRIPTION
i pull the  source from github.com  ,and fix up the startup file ,make has worked ,but it dose not work when i flash the elf file  to device, it lose libs,and the tree of source has the stm32 libs directory only,but not build yet,so i add it to Makefile and fix some mistakes,and Its already running in my device now!